### PR TITLE
Adding a UI layout component to use for common styling + example use case

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -64,7 +64,7 @@ module.exports = {
   // maxWorkers: "50%",
 
   // An array of directory names to be searched recursively up from the requiring module's location
-  moduleDirectories: ["node_modules"],
+  moduleDirectories: ["node_modules", "src"],
 
   // An array of file extensions your modules use
   moduleFileExtensions: ["js", "json", "jsx", "ts", "tsx", "node"],

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
+    "@types/classnames": "^2.2.10",
     "@types/react-dom": "^16.9.5",
+    "classnames": "^2.2.6",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   }

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -1,3 +1,7 @@
+body {
+  font-family: "Helvetica", sans-serif;
+}
+
 /**
  * Sample Style
  */
@@ -5,7 +9,7 @@ $steps: 30;
 @keyframes rainbow-shift {
   @for $i from 0 through $steps {
     #{percentage($i * (1 / $steps))} {
-      color: hsla(random(360), 100, 50, 1)
+      color: hsla(random(360), 100, 50, 1);
     }
   }
 }
@@ -15,15 +19,4 @@ $steps: 30;
   animation-duration: 60s;
   animation-iteration-count: infinite;
   animation-direction: alternate;
-}
-
-.container {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  
-  .header {
-    grid-column-start: 2;
-    margin: auto;
-    font-family: "Courier New";
-  }
 }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -13,7 +13,11 @@ const App: React.FunctionComponent<AppProps> = (props: AppProps) => {
       justifyContent={JustifyContent.Center}
       className="container"
     >
-      <Layout margin={{ x: 1 }} className="header">
+      <Layout
+        margin={{ x: 1, y: 1 }}
+        padding={{ x: 1, y: 1 }}
+        className="header"
+      >
         <h1 className="shifting-rainbow-text">{props.message}</h1>
       </Layout>
     </Layout>

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,18 +1,22 @@
 import * as React from "react";
+import { Layout, Display, JustifyContent } from "ui";
 import "./app.scss";
 
 type AppProps = {
   message: string;
 };
 
-/**
- * Sample App
- */
 const App: React.FunctionComponent<AppProps> = (props: AppProps) => {
   return (
-    <div className={"container"}>
-      <h1 className={"header shifting-rainbow-text"}>{props.message}</h1>
-    </div>
+    <Layout
+      display={Display.Flex}
+      justifyContent={JustifyContent.Center}
+      className="container"
+    >
+      <Layout margin={{ x: 1 }} className="header">
+        <h1 className="shifting-rainbow-text">{props.message}</h1>
+      </Layout>
+    </Layout>
   );
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import App from "components/app";
 
 window.addEventListener("DOMContentLoaded", () => {
-  console.log("JavaScript is Working");
   const greeting = "Hello RCubed";
   ReactDOM.render(<App message={greeting} />, document.getElementById("root"));
 });

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,1 @@
+export * from "./layout";

--- a/src/ui/layout/component.test.tsx
+++ b/src/ui/layout/component.test.tsx
@@ -9,6 +9,15 @@ describe("<Layout /> renders", () => {
     expect(wrapper.exists(".test-selector")).toEqual(true);
   });
 
+  it("should wrap HTML elements", () => {
+    const wrapper = shallow(
+      <Layout>
+        <div className="test-selector" />
+      </Layout>,
+    );
+    expect(wrapper.exists(".test-selector")).toEqual(true);
+  });
+
   describe("should append padding", () => {
     it("accepts x and y", () => {
       const wrapper = shallow(<Layout padding={{ x: 1, y: 1 }} />);

--- a/src/ui/layout/component.test.tsx
+++ b/src/ui/layout/component.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Layout from "./component";
+import * as Models from "./models";
+
+describe("<Layout /> renders", () => {
+  it("should append className", () => {
+    const wrapper = shallow(<Layout className="test-selector" />);
+    expect(wrapper.exists(".test-selector")).toEqual(true);
+  });
+
+  describe("should append padding", () => {
+    it("accepts x and y", () => {
+      const wrapper = shallow(<Layout padding={{ x: 1, y: 1 }} />);
+      expect(wrapper.exists(".px-1")).toEqual(true);
+      expect(wrapper.exists(".py-1")).toEqual(true);
+    });
+
+    it("accepts cardinal directions", () => {
+      const wrapper = shallow(<Layout padding={{ t: 1, r: 1, b: 1, l: 1 }} />);
+      expect(wrapper.exists(".pt-1")).toEqual(true);
+      expect(wrapper.exists(".pr-1")).toEqual(true);
+      expect(wrapper.exists(".pb-1")).toEqual(true);
+      expect(wrapper.exists(".pl-1")).toEqual(true);
+    });
+  });
+
+  describe("should append margin", () => {
+    it("accepts x and y", () => {
+      const wrapper = shallow(<Layout margin={{ x: 1, y: 1 }} />);
+      expect(wrapper.exists(".mx-1")).toEqual(true);
+      expect(wrapper.exists(".my-1")).toEqual(true);
+    });
+
+    it("accepts cardinal directions", () => {
+      const wrapper = shallow(<Layout margin={{ t: 1, r: 1, b: 1, l: 1 }} />);
+      expect(wrapper.exists(".mt-1")).toEqual(true);
+      expect(wrapper.exists(".mr-1")).toEqual(true);
+      expect(wrapper.exists(".mb-1")).toEqual(true);
+      expect(wrapper.exists(".ml-1")).toEqual(true);
+    });
+  });
+
+  describe("should append position", () => {
+    it("accepts relative position", () => {
+      const wrapper = shallow(<Layout position={Models.Position.Relative} />);
+      expect(wrapper.exists(".relative")).toEqual(true);
+    });
+    it("accepts absolute position", () => {
+      const wrapper = shallow(<Layout position={Models.Position.Absolute} />);
+      expect(wrapper.exists(".absolute")).toEqual(true);
+    });
+  });
+
+  describe("should append display", () => {
+    it("accepts flex", () => {
+      const wrapper = shallow(<Layout display={Models.Display.Flex} />);
+      expect(wrapper.exists(".flex")).toEqual(true);
+    });
+    it("accepts block", () => {
+      const wrapper = shallow(<Layout display={Models.Display.Block} />);
+      expect(wrapper.exists(".block")).toEqual(true);
+    });
+    it("accepts inline", () => {
+      const wrapper = shallow(<Layout display={Models.Display.Inline} />);
+      expect(wrapper.exists(".inline")).toEqual(true);
+    });
+  });
+
+  describe("should append flex properties", () => {
+    it("should append a flex direction", () => {
+      const wrapper = shallow(
+        <Layout flexDirection={Models.FlexDirection.Row} />,
+      );
+      expect(wrapper.exists(".flex-row")).toEqual(true);
+    });
+
+    it("should append a flex wrap", () => {
+      const wrapper = shallow(<Layout flexWrap={Models.FlexWrap.NoWrap} />);
+      expect(wrapper.exists(".flex-no-wrap")).toEqual(true);
+    });
+
+    it("should append a flex justify content", () => {
+      const wrapper = shallow(
+        <Layout justifyContent={Models.JustifyContent.Center} />,
+      );
+      expect(wrapper.exists(".flex-justify-center")).toEqual(true);
+    });
+
+    it("should append a flex align items", () => {
+      const wrapper = shallow(<Layout alignItems={Models.AlignItems.Center} />);
+      expect(wrapper.exists(".flex-align-items-center")).toEqual(true);
+    });
+
+    it("should append a flex align content", () => {
+      const wrapper = shallow(
+        <Layout alignContent={Models.AlignContent.Center} />,
+      );
+      expect(wrapper.exists(".flex-align-content-center")).toEqual(true);
+    });
+  });
+});

--- a/src/ui/layout/component.tsx
+++ b/src/ui/layout/component.tsx
@@ -43,11 +43,9 @@ type Props = PublicProps;
 const getPadding = (padding: Padding = {}): string[] => {
   const classes: string[] = [];
 
-  if (padding) {
-    Object.keys(padding).forEach(key => {
-      classes.push(`p${key}-${padding[key]}`);
-    });
-  }
+  Object.keys(padding).forEach(key => {
+    classes.push(`p${key}-${padding[key]}`);
+  });
 
   return classes;
 };
@@ -55,11 +53,9 @@ const getPadding = (padding: Padding = {}): string[] => {
 const getMargin = (margin: Margin = {}): string[] => {
   const classes: string[] = [];
 
-  if (margin) {
-    Object.keys(margin).forEach(key => {
-      classes.push(`m${key}-${margin[key]}`);
-    });
-  }
+  Object.keys(margin).forEach(key => {
+    classes.push(`m${key}-${margin[key]}`);
+  });
 
   return classes;
 };

--- a/src/ui/layout/component.tsx
+++ b/src/ui/layout/component.tsx
@@ -1,0 +1,89 @@
+import classNames from "classnames";
+import React, { Component, ReactElement } from "react";
+import {
+  AlignContent,
+  AlignItems,
+  Display,
+  FlexDirection,
+  FlexWrap,
+  JustifyContent,
+  Position,
+} from "./models";
+import "./style.scss";
+
+interface PublicProps {
+  className?: string;
+  padding?: Padding;
+  margin?: Margin;
+  display?: Display;
+  flexDirection?: FlexDirection;
+  flexWrap?: FlexWrap;
+  justifyContent?: JustifyContent;
+  alignItems?: AlignItems;
+  alignContent?: AlignContent;
+  position?: Position;
+}
+
+interface Spacing {
+  y?: size;
+  x?: size;
+  t?: size;
+  b?: size;
+  r?: size;
+  l?: size;
+  [key: string]: size | undefined;
+}
+
+type size = 1 | 2 | 3 | 4 | 5;
+type Padding = Spacing;
+type Margin = Spacing;
+type Props = PublicProps;
+
+class Layout extends Component<Props> {
+  public render(): ReactElement {
+    const paddingClass = classNames([
+      this.props.className,
+      ...this.getPadding(),
+      ...this.getMargin(),
+      this.props.display,
+      this.props.flexDirection,
+      this.props.flexWrap,
+      this.props.justifyContent,
+      this.props.alignItems,
+      this.props.alignContent,
+      this.props.position,
+    ]);
+    return <div className={paddingClass}>{this.props.children}</div>;
+  }
+
+  private getPadding(): string[] {
+    const classes: string[] = [];
+    const { padding } = this.props;
+
+    if (!padding) {
+      return [];
+    }
+
+    Object.keys(padding).forEach(key => {
+      classes.push(`p${key}-${padding[key]}`);
+    });
+
+    return classes;
+  }
+
+  private getMargin(): string[] {
+    const classes: string[] = [];
+    const { margin } = this.props;
+
+    if (!margin) {
+      return [];
+    }
+
+    Object.keys(margin).forEach(key => {
+      classes.push(`m${key}-${margin[key]}`);
+    });
+    return classes;
+  }
+}
+
+export default Layout;

--- a/src/ui/layout/component.tsx
+++ b/src/ui/layout/component.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { Component, ReactElement } from "react";
+import React, { PureComponent, ReactElement } from "react";
 import {
   AlignContent,
   AlignItems,
@@ -25,21 +25,21 @@ interface PublicProps {
 }
 
 interface Spacing {
-  y?: size;
-  x?: size;
-  t?: size;
-  b?: size;
-  r?: size;
-  l?: size;
-  [key: string]: size | undefined;
+  y?: Size;
+  x?: Size;
+  t?: Size;
+  b?: Size;
+  r?: Size;
+  l?: Size;
+  [key: string]: Size | undefined;
 }
 
-type size = 1 | 2 | 3 | 4 | 5;
+type Size = 1 | 2 | 3 | 4 | 5;
 type Padding = Spacing;
 type Margin = Spacing;
 type Props = PublicProps;
 
-class Layout extends Component<Props> {
+class Layout extends PureComponent<Props> {
   public render(): ReactElement {
     const paddingClass = classNames([
       this.props.className,

--- a/src/ui/layout/component.tsx
+++ b/src/ui/layout/component.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { PureComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactNode } from "react";
 import {
   AlignContent,
   AlignItems,
@@ -12,6 +12,7 @@ import {
 import "./style.scss";
 
 interface PublicProps {
+  children?: ReactNode;
   className?: string;
   padding?: Padding;
   margin?: Margin;
@@ -39,51 +40,45 @@ type Padding = Spacing;
 type Margin = Spacing;
 type Props = PublicProps;
 
-class Layout extends PureComponent<Props> {
-  public render(): ReactElement {
-    const paddingClass = classNames([
-      this.props.className,
-      ...this.getPadding(),
-      ...this.getMargin(),
-      this.props.display,
-      this.props.flexDirection,
-      this.props.flexWrap,
-      this.props.justifyContent,
-      this.props.alignItems,
-      this.props.alignContent,
-      this.props.position,
-    ]);
-    return <div className={paddingClass}>{this.props.children}</div>;
-  }
+const getPadding = (padding: Padding = {}): string[] => {
+  const classes: string[] = [];
 
-  private getPadding(): string[] {
-    const classes: string[] = [];
-    const { padding } = this.props;
-
-    if (!padding) {
-      return [];
-    }
-
+  if (padding) {
     Object.keys(padding).forEach(key => {
       classes.push(`p${key}-${padding[key]}`);
     });
-
-    return classes;
   }
 
-  private getMargin(): string[] {
-    const classes: string[] = [];
-    const { margin } = this.props;
+  return classes;
+};
 
-    if (!margin) {
-      return [];
-    }
+const getMargin = (margin: Margin = {}): string[] => {
+  const classes: string[] = [];
 
+  if (margin) {
     Object.keys(margin).forEach(key => {
       classes.push(`m${key}-${margin[key]}`);
     });
-    return classes;
   }
-}
+
+  return classes;
+};
+
+const Layout: FunctionComponent<Props> = (props: Props) => {
+  const paddingClass = classNames([
+    props.className,
+    ...getPadding(props.padding),
+    ...getMargin(props.margin),
+    props.display,
+    props.flexDirection,
+    props.flexWrap,
+    props.justifyContent,
+    props.alignItems,
+    props.alignContent,
+    props.position,
+  ]);
+
+  return <div className={paddingClass}>{props.children}</div>;
+};
 
 export default Layout;

--- a/src/ui/layout/index.ts
+++ b/src/ui/layout/index.ts
@@ -1,0 +1,2 @@
+export * from "./models";
+export { default as Layout } from "./component";

--- a/src/ui/layout/models.ts
+++ b/src/ui/layout/models.ts
@@ -1,0 +1,49 @@
+export enum Display {
+  Flex = "flex",
+  Block = "block",
+  Inline = "inline",
+}
+
+export enum FlexDirection {
+  Row = "flex-row",
+  RowReverse = "flex-row-reverse",
+  Column = "flex-column",
+  ColumnReverse = "flex-column-reverse",
+}
+
+export enum FlexWrap {
+  NoWrap = "flex-no-wrap",
+  Wrap = "flex-wrap",
+  WrapReverse = "flex-wrap-reverse",
+}
+
+export enum JustifyContent {
+  FlexStart = "flex-justify-start",
+  FlexEnd = "flex-justify-end",
+  Center = "flex-justify-center",
+  SpaceBetween = "flex-justify-space-between",
+  SpaceAround = "flex-justify-space-around",
+  SpaceEvenly = "flex-justify-space-evenly",
+}
+
+export enum AlignItems {
+  Stretch = "flex-align-items-stretch",
+  FlexStart = "flex-align-items-start",
+  FlexEnd = "flex-align-items-emd",
+  Center = "flex-align-items-center",
+  Baseline = "flex-align-items-baseline",
+}
+
+export enum AlignContent {
+  FlexStart = "flex-align-content-start",
+  FlexEnd = "flex-align-content-end",
+  Center = "flex-align-content-center",
+  SpaceBetween = "flex-align-content-space-between",
+  SpaceAround = "flex-align-content-space-around",
+  Stretch = "flex-align-content-stretch",
+}
+
+export enum Position {
+  Relative = "relative",
+  Absolute = "absolute",
+}

--- a/src/ui/layout/style.scss
+++ b/src/ui/layout/style.scss
@@ -1,0 +1,168 @@
+$spacings: 5;
+$directions: "y", "x", "t", "b", "r", "l";
+
+@each $direction in $directions {
+  @for $i from 1 through $spacings {
+    .p#{$direction}-#{$i} {
+      @if ($direction== "y") or ($direction== "t") {
+        padding-top: #{$i}rem;
+      }
+
+      @if ($direction== "y") or ($direction== "b") {
+        padding-bottom: #{$i}rem;
+      }
+
+      @if ($direction== "x") or ($direction== "r") {
+        padding-right: #{$i}rem;
+      }
+
+      @if ($direction== "x") or ($direction== "l") {
+        padding-left: #{$i}rem;
+      }
+    }
+  }
+}
+
+@each $direction in $directions {
+  @for $i from 1 through $spacings {
+    .m#{$direction}-#{$i} {
+      @if ($direction== "y") or ($direction== "t") {
+        margin-top: #{$i}rem;
+      }
+
+      @if ($direction== "y") or ($direction== "b") {
+        margin-bottom: #{$i}rem;
+      }
+
+      @if ($direction== "x") or ($direction== "r") {
+        margin-right: #{$i}rem;
+      }
+
+      @if ($direction== "x") or ($direction== "l") {
+        margin-left: #{$i}rem;
+      }
+    }
+  }
+}
+
+.flex {
+  display: flex;
+
+  &-row {
+    flex-direction: row;
+  }
+
+  &-row-reverse {
+    flex-direction: row-reverse;
+  }
+
+  &-column {
+    flex-direction: column;
+  }
+
+  &-column-reverse {
+    flex-direction: column-reverse;
+  }
+
+  &-no-wrap {
+    flex-wrap: nowrap;
+  }
+
+  &-wrap {
+    flex-wrap: wrap;
+  }
+
+  &-wrap-reverse {
+    flex-wrap: wrap-reverse;
+  }
+
+  &-justify {
+    &-start {
+      justify-content: flex-start;
+    }
+
+    &-end {
+      justify-content: flex-end;
+    }
+
+    &-center {
+      justify-content: center;
+    }
+
+    &-space-between {
+      justify-content: space-between;
+    }
+
+    &-space-around {
+      justify-content: space-around;
+    }
+
+    &-space-evenly {
+      justify-content: space-evenly;
+    }
+  }
+
+  &-align-items {
+    &-start {
+      align-items: flex-start;
+    }
+
+    &-end {
+      align-items: flex-end;
+    }
+
+    &-center {
+      align-items: center;
+    }
+
+    &-stretch {
+      align-items: stretch;
+    }
+
+    &-baseline {
+      align-items: baseline;
+    }
+  }
+
+  &-align-content {
+    &-start {
+      align-content: flex-start;
+    }
+
+    &-end {
+      align-content: flex-end;
+    }
+
+    &-center {
+      align-content: center;
+    }
+
+    &-space-between {
+      align-content: space-between;
+    }
+
+    &-space-around {
+      align-content: space-around;
+    }
+
+    &-stretch {
+      align-content: stretch;
+    }
+  }
+}
+
+.block {
+  display: block;
+}
+
+.inline {
+  display: inline;
+}
+
+.relative {
+  position: relative;
+}
+
+.absolute {
+  position: absolute;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,6 +444,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/classnames@^2.2.10":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
+  integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1675,6 +1680,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.2.x:
   version "4.2.3"


### PR DESCRIPTION
## Changes
1. Adding a `Layout` component that should be used in place of common `div` elements that require any basic styling.
	* As seen in `app.tsx` and `app.scss`, we can remove a lot of common styling needed by just using the `Layout` component and some nice props.
	* Example:
		```tsx
		<Layout margin={{ x: 1, y: 1 }}>
			<h1>Hello World</h1>
		</Layout>
		```
1. Added tests for the new `Layout` component.
1. Updated `moduleDirectories` in the jest config so that it can read absolute paths.
1. Imported `classnames` npm package.
	* This allows you to programmatically add an array of class names instead of doing string building.
	* Example:
	  ```ts
	  classNames([
	      this.props.className,
	      ...this.getPadding(),
	      ...this.getMargin(),
	      this.props.display,
	      this.props.flexDirection,
	      this.props.flexWrap,
	      this.props.justifyContent,
	      this.props.alignItems,
	      this.props.alignContent,
	      this.props.position,
	  ])
	  ```

## Code Coverage Result
```
yarn run v1.22.0
$ jest --coverage
 PASS  src/components/app/app.test.tsx
 PASS  src/ui/layout/component.test.tsx
----------------|---------|----------|---------|---------|-------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------|---------|----------|---------|---------|-------------------
All files       |     100 |      100 |     100 |     100 |
 components/app |     100 |      100 |     100 |     100 |
  app.tsx       |     100 |      100 |     100 |     100 |
 ui             |     100 |      100 |     100 |     100 |
  index.ts      |     100 |      100 |     100 |     100 |
 ui/layout      |     100 |      100 |     100 |     100 |
  component.tsx |     100 |      100 |     100 |     100 |
  index.ts      |     100 |      100 |     100 |     100 |
  models.ts     |     100 |      100 |     100 |     100 |
----------------|---------|----------|---------|---------|-------------------
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        1.964s, estimated 2s
Ran all test suites.
✨  Done in 2.72s.
```